### PR TITLE
Fix compile error in MapTileSource

### DIFF
--- a/MapGraphics/MapTileSource.cpp
+++ b/MapGraphics/MapTileSource.cpp
@@ -150,7 +150,7 @@ QImage *MapTileSource::fromMemCache(const QString &cacheID)
     return toRet;
 }
 
-void MapTileSource::toMemCache(const QString &cacheID, QImage *toCache, QDateTime &expireTime)
+void MapTileSource::toMemCache(const QString &cacheID, QImage *toCache, const QDateTime &expireTime)
 {
     if (toCache == 0)
         return;
@@ -218,7 +218,7 @@ QImage *MapTileSource::fromDiskCache(const QString &cacheID)
     return image;
 }
 
-void MapTileSource::toDiskCache(const QString &cacheID, QImage *toCache, QDateTime& expireTime)
+void MapTileSource::toDiskCache(const QString &cacheID, QImage *toCache, const QDateTime &expireTime)
 {
     //Figure out x,y,z based on the cacheID
     quint32 x,y,z;

--- a/MapGraphics/MapTileSource.h
+++ b/MapGraphics/MapTileSource.h
@@ -204,7 +204,7 @@ protected:
      * @param cacheID
      * @param toCache
      */
-    void toMemCache(const QString& cacheID, QImage * toCache, QDateTime &expireTime = QDateTime());
+    void toMemCache(const QString& cacheID, QImage * toCache, const QDateTime &expireTime = QDateTime());
 
     /**
      * @brief Given a cacheID, retrieve the tile with that cacheID from the disk cache. Returns a
@@ -226,7 +226,7 @@ protected:
      * @param toCache
      * @param cacheUntil
      */
-    void toDiskCache(const QString& cacheID, QImage * toCache, QDateTime &expireTime = QDateTime());
+    void toDiskCache(const QString& cacheID, QImage * toCache, const QDateTime &expireTime = QDateTime());
 
     /**
      * @brief Fetches (from MapQuest or OSM or whatever) or generates the tile if it isn't cached.

--- a/MapGraphics/MapTileSource.h
+++ b/MapGraphics/MapTileSource.h
@@ -219,8 +219,8 @@ protected:
     /**
      * @brief Given a cacheID and a pointer to a QImage, inserts the QImage pointed to by the pointer into
      * the disk cache using cacheID as the key.
-     * Optionally, takes a pointer to a QDateTime object that specifies the time that the QImage should be
-     * kept cached until. Defaults to 7 days. You are responsbile for deleting the QDateTime that's passed in
+     * Optionally, takes a QDateTime object that specifies the time that the QImage should be kept cached 
+     * until. Defaults to 7 days.
      *
      * @param cacheID
      * @param toCache


### PR DESCRIPTION
The MapTileSource class has a couple functions that take `QDateTime` objects to specify expiration times. These parameters default to temporaries created by invoking the `QDateTime` default constructor. However, they are specified as being non-`const` references, which cannot bind to temporaries. Change these parameters to be defined as `const` references.