### PR TITLE
MapGraphicsNetwork: use mutex to protect QHash list

### DIFF
--- a/MapGraphics/guts/MapGraphicsNetwork.cpp
+++ b/MapGraphics/guts/MapGraphicsNetwork.cpp
@@ -1,5 +1,6 @@
 #include "MapGraphicsNetwork.h"
 
+#include <QMutexLocker>
 #include <QNetworkRequest>
 #include <QThread>
 #include <QtDebug>
@@ -8,11 +9,12 @@ const QByteArray DEFAULT_USER_AGENT = "MapGraphics";
 
 //static
 QHash<QThread *, MapGraphicsNetwork *> MapGraphicsNetwork::_instances = QHash<QThread *, MapGraphicsNetwork*>();
+QMutex MapGraphicsNetwork::_mutex;
 
 //static
 MapGraphicsNetwork *MapGraphicsNetwork::getInstance()
 {
-
+    QMutexLocker lock(&_mutex);
     QThread * current = QThread::currentThread();
     if (!MapGraphicsNetwork::_instances.contains(current))
         MapGraphicsNetwork::_instances.insert(current, new MapGraphicsNetwork());

--- a/MapGraphics/guts/MapGraphicsNetwork.h
+++ b/MapGraphics/guts/MapGraphicsNetwork.h
@@ -1,6 +1,7 @@
 #ifndef MAPGRAPHICSNETWORK_H
 #define MAPGRAPHICSNETWORK_H
 
+#include <QMutex>
 #include <QNetworkAccessManager>
 #include <QHash>
 
@@ -21,6 +22,7 @@ protected:
 
 private:
     static QHash<QThread *, MapGraphicsNetwork *> _instances;
+    static QMutex _mutex;
     QNetworkAccessManager * _manager;
 
     QByteArray _userAgent;


### PR DESCRIPTION
The list could be accessed concurrently if multiple threads call
MapGraphicsNetwork::getInstance() at the same time. If one thread
attempts to insert into the list while another is accessing it,
crashes can occur.