### PR TITLE
Changes for Qt6 compatibility

### DIFF
--- a/MapGraphics/MapGraphics.pro
+++ b/MapGraphics/MapGraphics.pro
@@ -7,6 +7,8 @@
 QT       += network sql
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
+greaterThan(QT_MAJOR_VERSION, 5): QT += core5compat
+
 TARGET = MapGraphics
 TEMPLATE = lib
 
@@ -69,17 +71,100 @@ symbian {
     DEPLOYMENT += addFiles
 }
 
-unix:!symbian {
-    maemo5 {
-        target.path = /opt/usr/lib
-    } else {
-        target.path = /usr/lib
-    }
-    INSTALLS += target
-}
+#unix:!symbian {
+#    maemo5 {
+#        target.path = /opt/usr/lib
+#    } else {
+#        target.path = /usr/lib
+#    }
+#    INSTALLS += target
+#}
 
 FORMS += \
     guts/CompositeTileSourceConfigurationWidget.ui
 
 RESOURCES += \
     resources.qrc
+
+# BUILD OUTPUT DIR outside of parent MapGraphics
+# MapGraphics_BUILD at the same dir level of MapGraphics
+message( 'Building BUILD_OUT_DIR= $${OUT_PWD} ' )
+
+
+message( 'Building QMAKESPEC= $${QMAKESPEC} ' )
+#-------------------------------------------------
+# WIN32
+#-------------------------------------------------
+win32{
+    message( 'Building TARGET win32 WINDOWS_TARGET_PLATFORM_VERSION= $${WINDOWS_TARGET_PLATFORM_VERSION}' )
+    CONFIG(release, debug|release){
+        message( 'Building TARGET win32 release' )
+        target.path = $$PWD/../../MapGraphics_BUILD/LIB_BINARY/MSVC2019_64bit-Release
+        DESTDIR = $${target.path}
+    }
+    CONFIG(debug, debug|release){
+        message( 'Building TARGET win32 debug' )
+
+    }
+}
+
+
+#-------------------------------------------------
+# ANDROID
+#-------------------------------------------------
+android {
+    message('Building android')
+    message('Building android ANDROID_TARGET_ARCH $${ANDROID_TARGET_ARCH}')
+
+    contains(ANDROID_TARGET_ARCH,x86_64) {
+        message('Building android for x86_64')
+        #ANDROID_EXTRA_LIBS =
+        # message('Building ANDROID_TARGET_ARCH x86_64  ANDROID_EXTRA_LIBS=$${ANDROID_EXTRA_LIBS}')
+        #LIBS += -L$$PWD/ -l
+        #INCLUDEPATH += $$PWD/.....
+        #DEPENDPATH += $$PWD/......
+
+        #top_builddir=$$shadowed($$PWD)
+        #DESTDIR = $$top_builddir/plugins/myplugin
+        #DESTDIR = ../TestApp
+        target.path = $$PWD/../../MapGraphics_BUILD/LIB_BINARY/Clang_x86_64-Release
+        DESTDIR = $${target.path}
+        #INSTALLS += target
+        message( 'Building android INSTALLS= $${target.path} ' )
+    }
+
+    contains(ANDROID_TARGET_ARCH,arm64-v8a) {
+        message( 'Building android for arm64-v8a' )
+        #ANDROID_EXTRA_LIBS =
+        # message('Building ANDROID_TARGET_ARCH x86_64  ANDROID_EXTRA_LIBS=$${ANDROID_EXTRA_LIBS}')
+        #LIBS += -L$$PWD/ -l
+        #INCLUDEPATH += $$PWD/.....
+        #DEPENDPATH += $$PWD/......
+        #top_builddir=$$shadowed($$PWD)
+        #DESTDIR = $$top_builddir/plugins/myplugin
+        #DESTDIR = ../TestApp
+        target.path = $$PWD/../../MapGraphics_BUILD/LIB_BINARY/Clang_arm64-v8a-Release
+        DESTDIR = $${target.path}
+        #INSTALLS += target
+        message( 'Building android INSTALLS= $${target.path} ' )
+    }
+
+    android: include(C:/TOOLS/ANDROID/android_openssl/openssl.pri)
+}
+
+#-------------------------------------------------
+# iOs Configuration
+#-------------------------------------------------
+ios {
+    message( 'Building ios : QMAKE_TARGET= $${QMAKE_TARGET} QMAKE_MACOSX_DEPLOYMENT_TARGET= $${QMAKE_MACOSX_DEPLOYMENT_TARGET}' )
+     # iOs simulator
+    #target.path = $$PWD/../../MapGraphics_BUILD/LIB_BINARY/iOS_Simulator-Release
+    #DESTDIR = $${target.path}
+    #message( 'Building ios simulator' )
+
+    # iOs phone
+    target.path = $$PWD/../../MapGraphics_BUILD/LIB_BINARY/iOS-Release
+    DESTDIR = $${target.path}
+    message( 'Building ios phone' )
+
+}

--- a/MapGraphics/MapGraphicsView.h
+++ b/MapGraphics/MapGraphicsView.h
@@ -106,11 +106,12 @@ private:
 
     DragMode _dragMode;
 };
-
+/*
 inline uint qHash(const QPointF& key)
 {
     const QString temp = QString::number(key.x()) % "," % QString::number(key.y());
     return qHash(temp);
 }
+*/
 
 #endif // MAPGRAPHICSVIEW_H

--- a/MapGraphics/tileSources/CompositeTileSource.cpp
+++ b/MapGraphics/tileSources/CompositeTileSource.cpp
@@ -10,7 +10,11 @@
 CompositeTileSource::CompositeTileSource() :
     MapTileSource()
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    _globalMutex = new QRecursiveMutex();
+#else
     _globalMutex = new QMutex(QMutex::Recursive);
+#endif
     this->setCacheMode(MapTileSource::NoCaching);
 }
 

--- a/MapGraphics/tileSources/CompositeTileSource.h
+++ b/MapGraphics/tileSources/CompositeTileSource.h
@@ -81,7 +81,11 @@ private slots:
 
 private:
     void doChildThreading(QSharedPointer<MapTileSource>);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QRecursiveMutex* _globalMutex;
+#else
     QMutex * _globalMutex;
+#endif
     QList<QSharedPointer<MapTileSource> > _childSources;
     QList<qreal> _childOpacities;
     QList<bool> _childEnabledFlags;

--- a/MapGraphics/tileSources/OSMTileSource.cpp
+++ b/MapGraphics/tileSources/OSMTileSource.cpp
@@ -7,6 +7,9 @@
 #include <QStringBuilder>
 #include <QtDebug>
 #include <QNetworkReply>
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    #include <QtCore5Compat/QRegExp>
+#endif
 
 const qreal PI = 3.14159265358979323846;
 const qreal deg2rad = PI / 180.0;

--- a/TestApp/TestApp.pro
+++ b/TestApp/TestApp.pro
@@ -7,6 +7,8 @@
 QT       += core gui network sql
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
+greaterThan(QT_MAJOR_VERSION, 5): QT += core5compat
+
 TARGET = TestApp
 TEMPLATE = app
 
@@ -19,9 +21,87 @@ HEADERS  += MainWindow.h
 FORMS    += MainWindow.ui
 
 #Linkage for MapGraphics shared library
-win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../MapGraphics/release/ -lMapGraphics
-else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../MapGraphics/debug/ -lMapGraphics
-else:unix:!symbian: LIBS += -L$$OUT_PWD/../MapGraphics/ -lMapGraphics
+#win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../MapGraphics/release/ -lMapGraphics
+#else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../MapGraphics/debug/ -lMapGraphics
+#else:unix:!symbian: LIBS += -L$$OUT_PWD/../MapGraphics/ -lMapGraphics
 
 INCLUDEPATH += $$PWD/../MapGraphics
 DEPENDPATH += $$PWD/../MapGraphics
+
+# BUILD OUTPUT DIR outside of parent MapGraphics
+# MapGraphics_BUILD at the same dir level of MapGraphics
+message( 'Building BUILD_OUT_DIR= $${OUT_PWD} ' )
+
+message( 'Building QMAKESPEC= $${QMAKESPEC} ' )
+
+#-------------------------------------------------
+# WIN32 MSVC
+#-------------------------------------------------
+win32{
+    message( 'Building TARGET win32' )
+    CONFIG(release, debug|release){
+        message( 'Building TARGET win32 release' )
+        LIBS += -L$$PWD/../../MapGraphics_BUILD/LIB_BINARY/MSVC2019_64bit-Release/ -lMapGraphics
+        INCLUDEPATH += $$PWD/../../MapGraphics_BUILD/LIB_BINARY/MSVC2019_64bit-Release
+        DEPENDPATH += $$PWD/../../MapGraphics_BUILD/LIB_BINARY/MSVC2019_64bit-Release
+    }
+    CONFIG(debug, debug|release){
+        message( 'Building TARGET win32 debug' )
+
+    }
+}
+
+#-------------------------------------------------
+# ANDROID
+#-------------------------------------------------
+android {
+    message('Building android')
+    message('Building TARGET ANDROID_TARGET_ARCH $${ANDROID_TARGET_ARCH}')
+
+    contains(ANDROID_TARGET_ARCH,x86_64) {
+        message('Building android for x86_64')
+        ANDROID_EXTRA_LIBS = $$PWD/../../MapGraphics_BUILD/LIB_BINARY/Clang_x86_64-Release/libMapGraphics_x86_64.so
+        LIBS += -L$$PWD/../../MapGraphics_BUILD/LIB_BINARY/Clang_x86_64-Release/ -lMapGraphics_x86_64
+        INCLUDEPATH += $$PWD/../../MapGraphics_BUILD/LIB_BINARY/Clang_x86_64-Release
+        DEPENDPATH += $$PWD/../../MapGraphics_BUILD/LIB_BINARY/Clang_x86_64-Release
+        message('Building android for x86_64  ANDROID_EXTRA_LIBS=$${ANDROID_EXTRA_LIBS}')
+    }
+
+    contains(ANDROID_TARGET_ARCH,arm64-v8a) {
+        message( 'Building android for arm64-v8a' )
+        ANDROID_EXTRA_LIBS = $$PWD/../../MapGraphics_BUILD/LIB_BINARY/Clang_arm64-v8a-Release/libMapGraphics_arm64-v8a.so
+        LIBS += -L$$PWD/../../MapGraphics_BUILD/LIB_BINARY/Clang_arm64-v8a-Release/ -lMapGraphics_arm64-v8a
+        INCLUDEPATH += $$PWD/../../MapGraphics_BUILD/LIB_BINARY/Clang_arm64-v8a-Release
+        DEPENDPATH += $$PWD/../../MapGraphics_BUILD/LIB_BINARY/Clang_arm64-v8a-Release
+        message('Building android for x86_64  ANDROID_EXTRA_LIBS=$${ANDROID_EXTRA_LIBS}')
+    }
+    android: include(C:/TOOLS/ANDROID/android_openssl/openssl.pri)
+
+}
+
+#-------------------------------------------------
+# iOs Configuration
+#-------------------------------------------------
+ios{
+    # message( 'Building ios : QMAKE_MACOSX_DEPLOYMENT_TARGET= $${QMAKE_MACOSX_DEPLOYMENT_TARGET}' )
+    # iOs simulator
+    #LIBS += -L$$PWD/../../MapGraphics_BUILD/LIB_BINARY/iOS_Simulator-Release/ -lMapGraphics
+    #INCLUDEPATH += $$PWD/../../MapGraphics_BUILD/LIB_BINARY/iOS_Simulator-Release
+    #DEPENDPATH += $$PWD/../../MapGraphics_BUILD/LIB_BINARY/iOS_Simulator-Release
+    #message('Building ios simulator')
+
+    # iOs phone
+    LIBS += -L$$PWD/../../MapGraphics_BUILD/LIB_BINARY/iOS-Release/ -lMapGraphics
+    INCLUDEPATH += $$PWD/../../MapGraphics_BUILD/LIB_BINARY/iOS-Release
+    DEPENDPATH += $$PWD/../../MapGraphics_BUILD/LIB_BINARY/iOS-Release
+    message('Building ios')
+
+}
+
+
+#unix:!symbian
+#{
+    #LIBS += -L$$OUT_PWD/../MapGraphics/ -lMapGraphics
+#}
+
+message('Building using LIBS= $${LIBS} ')


### PR DESCRIPTION
I modified the code for compatibility with Qt6.
I modified the Shadow Build directory in order to save the output outside the MapGraphics directory.
To use Android and iOs kit, do you need to open the MapGraphics and TestApp directly and not as subprojects
I tested the  testapp with:
MSVC2019_64bit to make a Win executable on Win10
Android Clang_x86_64 to test in Android Emulator (No zoom features)
Android Clang_arm64-v8a and tested on an Huawey P10 lite Android 8 (No zoom features)
iOS XCode 13.2.1 iOs Simulator iPhone 11 Pro (No zoom features)